### PR TITLE
Make most string comparisons case-insensitive.

### DIFF
--- a/src/alias.c
+++ b/src/alias.c
@@ -48,7 +48,7 @@ void addalias (aliasarr_t *a, uint32_t ln, Token *word, Token *reg)
 int32_t findalias (aliasarr_t *a, Token *word)
 {
     for (uint16_t i = 0; i < a->ind; i++) {
-        if (strcmp (word->str, a->arr[i].word->str) == 0) {
+        if (strcasecmp (word->str, a->arr[i].word->str) == 0) {
             return i;
         }
     }

--- a/src/assemble.c
+++ b/src/assemble.c
@@ -672,8 +672,8 @@ void generateshared (labelarr_t* share, pnode_t *node)
     lineinfo_t **tmp = node->res.tokbufarr->arr;
     for (uint32_t i = 0; end; --end, ++i) {
         Token **tbuf = tmp[i]->buf->token;
-        if (strcmp(tbuf[0]->str, ".EXPORT") == 0 ||
-            strcmp(tbuf[0]->str, ".export") == 0)
+        if (strcasecmp(tbuf[0]->str, ".EXPORT") == 0 ||
+            strcasecmp(tbuf[0]->str, ".export") == 0)
         {
             uint32_t ln = tmp[i]->ln;
             if (tmp[i]->buf->toknum < 2) {
@@ -707,8 +707,8 @@ void extendprivate (labelarr_t* share, pnode_t *node)
     lineinfo_t **tmp = node->res.tokbufarr->arr;
     for (uint32_t i = 0; end; --end, ++i) {
         Token **tbuf = tmp[i]->buf->token;
-        if (strcmp(tbuf[0]->str, ".IMPORT") == 0 ||
-            strcmp(tbuf[0]->str, ".import") == 0)
+        if (strcasecmp(tbuf[0]->str, ".IMPORT") == 0 ||
+            strcasecmp(tbuf[0]->str, ".import") == 0)
         {
             uint32_t ln = tmp[i]->ln;
             if (tmp[i]->buf->toknum < 2) {

--- a/src/operand.c
+++ b/src/operand.c
@@ -24,36 +24,33 @@
 #define USES_OPERAND
 #include "laser.h"
 
-int8_t arrcmp (char *str, const char *arr[][2], uint8_t size)
+int8_t arrcmp (char *str, const char *arr[], uint8_t size)
 {
     for (uint8_t i = 0; i < size; i++) {
-        if (strcasecmp (str, arr[i][0]) == 0 ||
-            strcasecmp (str, arr[i][1]) == 0) return i;
+        if (strcasecmp (str, arr[i]) == 0) return i;
     }
     return -1;
 }
 
-int8_t brrcmp (char *str, const char *arr[][3], uint8_t size)
+int8_t brrcmp (char *str, const char *arr[], uint8_t size)
 {
     for (uint8_t i = 0; i < size; i++) {
-        if (strcasecmp (str, arr[i][0]) == 0 ||
-            strcasecmp (str, arr[i][1]) == 0 ||
-            strcasecmp (str, arr[i][2]) == 0) return i;
+        if (strcasecmp (str, arr[i]) == 0) return i;
     }
     return -1;
 }
 
 int8_t isregister (Token *token)
 {
-    const char *regs[][2] = {
-        {"R0", "r0"},
-        {"R1", "r1"},
-        {"R2", "r2"},
-        {"R3", "r3"},
-        {"R4", "r4"},
-        {"R5", "r5"},
-        {"R6", "r6"},
-        {"R7", "r7"}
+    const char *regs[] = {
+        "R0",
+        "R1",
+        "R2",
+        "R3",
+        "R4",
+        "R5",
+        "R6",
+        "R7",
     };
 
     return arrcmp (token->str, regs, 8);
@@ -61,15 +58,15 @@ int8_t isregister (Token *token)
 
 int8_t isbranch (Token *token)
 {
-    const char *brs[][3] = {
-        {"BR", "BR", "br"},
-        {"BRP", "BRp", "brp"},
-        {"BRZ", "BRz", "brz"},
-        {"BRZP", "BRzp", "brzp"},
-        {"BRN", "BRn", "brn"},
-        {"BRNP", "BRnp", "brnp"},
-        {"BRNZ", "BRnz", "brnz"},
-        {"BRNZP", "BRnzp", "brnzp"}
+    const char *brs[] = {
+        "BR",
+        "BRP",
+        "BRZ",
+        "BRZP",
+        "BRN",
+        "BRNP",
+        "BRNZ",
+        "BRNZP",
     };
 
     int8_t tmp = brrcmp (token->str, brs, 8);
@@ -79,21 +76,21 @@ int8_t isbranch (Token *token)
 
 int8_t istrap (Token *token)
 {
-    const char *traps[][2] = {
-        {"GETC", "getc"},
-        {"OUT", "out"},
-        {"PUTS", "puts"},
-        {"IN", "in"},
-        {"PUTSP", "putsp"},
-        {"HALT", "halt"},
-        {"TRAP", "trap"},
-        {"REG", "reg"},
-        {"CHAT", "chat"},
-        {"GETP", "getp"},
-        {"SETP", "setp"},
-        {"GETB", "getb"},
-        {"SETB", "setb"},
-        {"GETH", "geth"}
+    const char *traps[] = {
+        "GETC",
+        "OUT",
+        "PUTS",
+        "IN",
+        "PUTSP",
+        "HALT",
+        "TRAP",
+        "REG",
+        "CHAT",
+        "GETP",
+        "SETP",
+        "GETB",
+        "SETB",
+        "GETH",
     };
 
     int8_t tmp = arrcmp (token->str, traps, 14);
@@ -104,23 +101,23 @@ int8_t istrap (Token *token)
 
 int8_t isoperand (Token *token)
 {
-    const char *ops[][2] = {
-        {"BR", "br"},
-        {"ADD", "add"},
-        {"LD", "ld"},
-        {"ST", "st"},
-        {"JSR", "jsr"},
-        {"AND", "and"},
-        {"LDR", "ldr"},
-        {"STR", "str"},
-        {"RTI", "rti"},
-        {"NOT", "not"},
-        {"LDI", "ldi"},
-        {"STI", "sti"},
-        {"JMP", "jmp"},
-        {"", ""},
-        {"LEA", "lea"},
-        {"TRAP", "trap"}
+    const char *ops[] = {
+        "BR",
+        "ADD",
+        "LD",
+        "ST",
+        "JSR",
+        "AND",
+        "LDR",
+        "STR",
+        "RTI",
+        "NOT",
+        "LDI",
+        "STI",
+        "JMP",
+        "",
+        "LEA",
+        "TRAP",
     };
 
     int8_t op = arrcmp (token->str, ops, 16);

--- a/src/operand.c
+++ b/src/operand.c
@@ -27,8 +27,8 @@
 int8_t arrcmp (char *str, const char *arr[][2], uint8_t size)
 {
     for (uint8_t i = 0; i < size; i++) {
-        if (strcmp (str, arr[i][0]) == 0 ||
-            strcmp (str, arr[i][1]) == 0) return i;
+        if (strcasecmp (str, arr[i][0]) == 0 ||
+            strcasecmp (str, arr[i][1]) == 0) return i;
     }
     return -1;
 }
@@ -36,9 +36,9 @@ int8_t arrcmp (char *str, const char *arr[][2], uint8_t size)
 int8_t brrcmp (char *str, const char *arr[][3], uint8_t size)
 {
     for (uint8_t i = 0; i < size; i++) {
-        if (strcmp (str, arr[i][0]) == 0 ||
-            strcmp (str, arr[i][1]) == 0 ||
-            strcmp (str, arr[i][2]) == 0) return i;
+        if (strcasecmp (str, arr[i][0]) == 0 ||
+            strcasecmp (str, arr[i][1]) == 0 ||
+            strcasecmp (str, arr[i][2]) == 0) return i;
     }
     return -1;
 }
@@ -129,11 +129,11 @@ int8_t isoperand (Token *token)
             op = BR;
         } else if (istrap (token) >= 0) {
             op = TRAPS;
-        } else if (strcmp (token->str, "JSRR") == 0 ||
-                   strcmp (token->str, "jsrr") == 0) {
+        } else if (strcasecmp (token->str, "JSRR") == 0 ||
+                   strcasecmp (token->str, "jsrr") == 0) {
             op = JSRR;
-        } else if (strcmp (token->str, "RET") == 0 ||
-                   strcmp (token->str, "ret") == 0) {
+        } else if (strcasecmp (token->str, "RET") == 0 ||
+                   strcasecmp (token->str, "ret") == 0) {
             op = RET;
         }
     } else if (op == 13) {														// invalid op

--- a/src/pseudoop.c
+++ b/src/pseudoop.c
@@ -25,20 +25,20 @@
 #define USES_OFFSET
 #include "laser.h"
 
-int8_t arrcmp (char *str, const char *arr[][2], uint8_t size);
+int8_t arrcmp (char *str, const char *arr[], uint8_t size);
 
 int8_t ispseudoop (Token *token)
 {
-    const char *pops[][2] = {
-        ".ALIAS", ".alias",		// 0
-        ".MACRO", ".macro",		// 1
-        ".ORIG", ".orig",		// 2
-        ".END", ".end",			// 3
-        ".STRINGZ", ".stringz",	// 4
-        ".BLKW", ".blkw",		// 5
-        ".FILL", ".fill",		// 6
-        ".EXPORT", ".export",	// 7
-        ".IMPORT", ".import"	// 8
+    const char *pops[] = {
+        ".ALIAS",	// 0
+        ".MACRO",	// 1
+        ".ORIG",	// 2
+        ".END",		// 3
+        ".STRINGZ",	// 4
+        ".BLKW",	// 5
+        ".FILL",	// 6
+        ".EXPORT",	// 7
+        ".IMPORT"	// 8
     };
     return arrcmp (token->str, pops, 9);
 }


### PR DESCRIPTION
Use `strcasecmp` over `strcmp` for the following token types: instruction mnemonics, trap aliases, and preprocessor directives.
Does not affect label names or preprocessor macro names.

Affects https://github.com/rozukke/lace/issues/72